### PR TITLE
#169 Optimize objects

### DIFF
--- a/src/objects/IgnisRegularInner/IgnisRegularInner.gd
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.gd
@@ -70,6 +70,7 @@ func _process(delta):
 func checkEnergy():
 	if energy <= energyMin:
 		finish_disabling()
+		set_process(false)
 		switchedOff = true
 
 
@@ -91,6 +92,7 @@ func finish_disabling():
 func enable():
 	switchingOff = false
 	energy = energyMax
+	set_process(true)
 
 
 func finish_enabling():

--- a/src/objects/IgnisRegularInner/IgnisRegularInner.gd
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.gd
@@ -38,7 +38,7 @@ func _ready():
 # Called in ignisRegularLevel and ...Outer to increase radiuses
 func init_radius(mul):
 	texture_scale *= mul
-	$Area2D/CollisionShape2D.shape.radius *= mul
+	$Area2D.scale *= mul
 	minScale = texture_scale - 0.01
 	$VisibilityEnabler2D.scale *= mul
 

--- a/src/objects/IgnisRegularInner/IgnisRegularInner.gd
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.gd
@@ -9,8 +9,6 @@ var energyMax
 var switchingOff
 var switchedOff
 
-signal enabled
-signal disabled
 var priority = 1
 
 var reflected = 1
@@ -26,13 +24,11 @@ enum Ignis_layer{
 func _ready():
 	minScale = texture_scale - 0.01
 	energyMax = 1.2
-	switchingOff = not enabled
-	switchedOff = enabled
-	if switchedOff:
-		finish_disabling()
+	switchingOff = false
+	switchedOff = true
+	finish_disabling()
+	set_process(false)
 	set_visibility_flags(true)
-	if not $VisibilityEnabler2D.is_on_screen():
-		set_process(false)
 	pass # Replace with function body
 
 # Called in ignisRegularLevel and ...Outer to increase radiuses

--- a/src/objects/IgnisRegularInner/IgnisRegularInner.gd
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.gd
@@ -87,7 +87,6 @@ func finish_disabling():
 	enabled = false
 	energy = 0
 	switchedOff = true
-	emit_signal("disabled")
 
 
 func enable():
@@ -105,7 +104,6 @@ func finish_enabling():
 		$Area2D/CollisionShape2D.disabled = false
 	enabled = true
 	energy = energyMax
-	emit_signal("enabled")
 
 
 func mirror():

--- a/src/objects/IgnisRegularInner/IgnisRegularInner.gd
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.gd
@@ -30,6 +30,9 @@ func _ready():
 	switchedOff = enabled
 	if switchedOff:
 		finish_disabling()
+	set_visibility_flags(true)
+	if not $VisibilityEnabler2D.is_on_screen():
+		set_process(false)
 	pass # Replace with function body
 
 # Called in ignisRegularLevel and ...Outer to increase radiuses
@@ -37,6 +40,7 @@ func init_radius(mul):
 	texture_scale *= mul
 	$Area2D/CollisionShape2D.shape.radius *= mul
 	minScale = texture_scale - 0.01
+	$VisibilityEnabler2D.scale *= mul
 
 
 func set_light_layer(layer):
@@ -71,6 +75,7 @@ func checkEnergy():
 	if energy <= energyMin:
 		finish_disabling()
 		set_process(false)
+		set_visibility_flags(false)
 		switchedOff = true
 
 
@@ -93,6 +98,7 @@ func enable():
 	switchingOff = false
 	energy = energyMax
 	set_process(true)
+	set_visibility_flags(true)
 
 
 func finish_enabling():
@@ -113,3 +119,8 @@ func mirror():
 
 func rotate_ignis(degree):
 	pass
+
+
+func set_visibility_flags(val):
+	$VisibilityEnabler2D.process_parent = val
+	$VisibilityEnabler2D.pause_particles = val

--- a/src/objects/IgnisRegularInner/IgnisRegularInner.tscn
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.tscn
@@ -99,3 +99,11 @@ texture = ExtResource( 4 )
 amount = 32
 process_material = SubResource( 11 )
 texture = ExtResource( 2 )
+
+[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
+position = Vector2( 0.766579, 3.8147e-06 )
+scale = Vector2( 11.6553, 11.6808 )
+pause_animations = false
+freeze_bodies = false
+pause_particles = false
+pause_animated_sprites = false

--- a/src/objects/IgnisRegularInner/IgnisRegularInner.tscn
+++ b/src/objects/IgnisRegularInner/IgnisRegularInner.tscn
@@ -84,6 +84,14 @@ __meta__ = {
 "_edit_group_": true
 }
 
+[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
+position = Vector2( 0.766579, 3.8147e-06 )
+scale = Vector2( 11.6553, 11.6808 )
+pause_animations = false
+freeze_bodies = false
+pause_particles = false
+pause_animated_sprites = false
+
 [node name="Area2D" type="Area2D" parent="."]
 collision_layer = 8
 collision_mask = 8
@@ -99,11 +107,3 @@ texture = ExtResource( 4 )
 amount = 32
 process_material = SubResource( 11 )
 texture = ExtResource( 2 )
-
-[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
-position = Vector2( 0.766579, 3.8147e-06 )
-scale = Vector2( 11.6553, 11.6808 )
-pause_animations = false
-freeze_bodies = false
-pause_particles = false
-pause_animated_sprites = false

--- a/src/objects/IgnisSectorInner/IgnisSectorInner.gd
+++ b/src/objects/IgnisSectorInner/IgnisSectorInner.gd
@@ -89,6 +89,7 @@ func finishDisabling():
 	$Circle.energy = 0
 	energy = 0
 	switchedOff = true
+	set_process(false)
 	emit_signal("disabled")
 
 
@@ -96,6 +97,7 @@ func enable():
 	switchingOff = false
 	energy = energyMax
 	$Circle.energy = energyMax
+	set_process(true)
 
 
 func finishEnabling():

--- a/src/objects/IgnisSectorInner/IgnisSectorInner.gd
+++ b/src/objects/IgnisSectorInner/IgnisSectorInner.gd
@@ -13,8 +13,6 @@ var energyMax
 var switchingOff
 var switchedOff
 
-signal enabled
-signal disabled
 var priority = 1
 
 
@@ -23,10 +21,9 @@ func _ready():
 	minScaleCircle = $Circle.texture_scale
 	rotate(PI / 2)
 	energyMax = 1.2
-	switchingOff = not enabled
-	switchedOff = enabled
-	if switchedOff:
-		finishDisabling()
+	switchingOff = false
+	switchedOff = true
+	finishDisabling()
 	
 	pass # Replace with function body.
 
@@ -90,7 +87,6 @@ func finishDisabling():
 	energy = 0
 	switchedOff = true
 	set_process(false)
-	emit_signal("disabled")
 
 
 func enable():
@@ -109,4 +105,3 @@ func finishEnabling():
 	$Circle.enabled = true
 	energy = energyMax
 	$Circle.energy = energyMax
-	emit_signal("enabled")

--- a/src/objects/door/Door.gd
+++ b/src/objects/door/Door.gd
@@ -13,6 +13,7 @@ var bodies_below = 0
 func _ready():
 	src_height = $CollisionShape2D.shape.extents.y
 	max_height = $CollisionShape2D.shape.extents.y * 2
+	set_process(false)
 	pass # Replace with function body.
 
 #func _pro(delta):
@@ -46,6 +47,7 @@ func _process(delta):
 			position.y += height - max_height
 			height = max_height
 			step = 0
+			set_process(false)
 	elif step > 0 and bodies_below == 0:
 		$CollisionShape2D.shape.extents.y = height + src_height
 		var del = move(delta)
@@ -55,6 +57,7 @@ func _process(delta):
 			position.y += height
 			height = 0
 			step = 0
+			set_process(false)
 	#update()
 
 func move(delta):
@@ -67,12 +70,14 @@ func move(delta):
 func _on_IgnisRegularLevel_active():
 	linear_vel.y = -SPEED
 	step = -SPEED
+	set_process(true)
 	pass # Replace with function body.
 
 
 func _on_IgnisRegularLevel_not_active():
 	linear_vel.y = SPEED
 	step = SPEED
+	set_process(true)
 	pass # Replace with function body.
 
 #func _draw():

--- a/src/objects/heart/Heart.gd
+++ b/src/objects/heart/Heart.gd
@@ -6,6 +6,8 @@ var step = 20
 
 
 func _ready():
+	if not $VisibilityEnabler2D.is_on_screen():
+		set_process(false)
 	pass # Replace with function body.
 
 

--- a/src/objects/heart/Heart.tscn
+++ b/src/objects/heart/Heart.tscn
@@ -16,4 +16,13 @@ shape = SubResource( 1 )
 [node name="Sprite" type="Sprite" parent="."]
 scale = Vector2( 0.4, 0.4 )
 texture = ExtResource( 1 )
+
+[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
+position = Vector2( -0.524472, 0.0874143 )
+scale = Vector2( 1.26224, 1.23601 )
+pause_animations = false
+freeze_bodies = false
+pause_particles = false
+pause_animated_sprites = false
+process_parent = true
 [connection signal="body_entered" from="." to="." method="_on_Heart_body_entered"]

--- a/src/objects/heart/Heart.tscn
+++ b/src/objects/heart/Heart.tscn
@@ -9,14 +9,6 @@ extents = Vector2( 10.8794, 10.9422 )
 [node name="Heart" type="Area2D"]
 script = ExtResource( 2 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 0, 0.142397 )
-shape = SubResource( 1 )
-
-[node name="Sprite" type="Sprite" parent="."]
-scale = Vector2( 0.4, 0.4 )
-texture = ExtResource( 1 )
-
 [node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
 position = Vector2( -0.524472, 0.0874143 )
 scale = Vector2( 1.26224, 1.23601 )
@@ -25,4 +17,12 @@ freeze_bodies = false
 pause_particles = false
 pause_animated_sprites = false
 process_parent = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2( 0, 0.142397 )
+shape = SubResource( 1 )
+
+[node name="Sprite" type="Sprite" parent="."]
+scale = Vector2( 0.4, 0.4 )
+texture = ExtResource( 1 )
 [connection signal="body_entered" from="." to="." method="_on_Heart_body_entered"]


### PR DESCRIPTION
added:
- visibilityEnabler2D for ignisRegularInner to switch off processing while torches are not visible
- visibilityEnabler2D for Heart
fixed:
- processing ignisRegularInner (turning on and off process up to ignis status)
- door processing (use process only when active)